### PR TITLE
add properties for padding message inside bubble frame

### DIFF
--- a/CMPopTipView.podspec.json
+++ b/CMPopTipView.podspec.json
@@ -1,0 +1,20 @@
+{
+  "name": "CMPopTipView",
+  "version": "2.2.0",
+  "license": "MIT",
+  "summary": "Custom UIView for iOS that pops up an animated \"bubble\" pointing at a button or other view. Useful for popup tips.",
+  "homepage": "https://github.com/chrismiles/CMPopTipView",
+  "authors": {
+    "Chris Miles": "http://chrismiles.info/"
+  },
+  "source": {
+    "git": "https://github.com/bakkenlab/CMPopTipView.git",
+    "tag": "2.2.0-lbakken"
+  },
+  "platforms": {
+    "ios": "7.0"
+  },
+  "source_files": "CMPopTipView/*.{h,m}",
+  "frameworks": "UIKit",
+  "requires_arc": true
+}

--- a/CMPopTipView/CMPopTipView.h
+++ b/CMPopTipView/CMPopTipView.h
@@ -131,6 +131,10 @@ typedef NS_ENUM(NSInteger, CMPopTipAnimation) {
 @property (nonatomic, assign)           CGFloat                 sidePadding;
 @property (nonatomic, assign)           CGFloat                 topMargin;
 @property (nonatomic, assign)           CGFloat                 pointerSize;
+@property (nonatomic, assign)           CGFloat                 bubbleFrameWidth;
+@property (nonatomic, assign)           CGFloat                 bubbleFrameHeight;
+@property (nonatomic, assign)           CGFloat                 contentFrameYCoord;
+@property (nonatomic, assign)           CGFloat                 contentFrameXCoord;
 
 /* Contents can be either a message or a UIView */
 - (id)initWithTitle:(NSString *)titleToShow message:(NSString *)messageToShow;

--- a/CMPopTipView/CMPopTipView.m
+++ b/CMPopTipView/CMPopTipView.m
@@ -34,6 +34,10 @@
 	PointDirection			_pointDirection;
 	CGFloat					_pointerSize;
 	CGPoint					_targetPoint;
+    CGFloat                 _bubbleFrameWidth;
+    CGFloat                 _bubbleFrameHeight;
+    CGFloat                 _contentFrameYCoord;
+    CGFloat                 _contentFrameXCoord;
 }
 
 @property (nonatomic, strong, readwrite)	id	targetObject;
@@ -47,7 +51,7 @@
 - (CGRect)bubbleFrame {
 	CGRect bubbleFrame;
 	if (_pointDirection == PointDirectionUp) {
-		bubbleFrame = CGRectMake(_sidePadding, _targetPoint.y+_pointerSize, _bubbleSize.width, _bubbleSize.height);
+		bubbleFrame = CGRectMake(_sidePadding, _targetPoint.y+_pointerSize, _bubbleSize.width + _bubbleFrameWidth, _bubbleSize.height + _bubbleFrameHeight);
 	}
 	else {
 		bubbleFrame = CGRectMake(_sidePadding, _targetPoint.y-_pointerSize-_bubbleSize.height, _bubbleSize.width, _bubbleSize.height);
@@ -61,6 +65,10 @@
 									 bubbleFrame.origin.y + _cornerRadius,
 									 bubbleFrame.size.width - _cornerRadius*2,
 									 bubbleFrame.size.height - _cornerRadius*2);
+    
+    contentFrame.origin.x += _contentFrameXCoord;
+    contentFrame.origin.y += _contentFrameYCoord;
+    
 	return contentFrame;
 }
 


### PR DESCRIPTION
When the message is added to the bubble you cannot change the surrounding padding of it. 

This allows you to change the width and height of the bubble and the x and y coordinates of the content frame so padding can be added to the message inside.
